### PR TITLE
Declaration annotations don't apply to array component types (Fixes #…

### DIFF
--- a/checker/tests/nullness/Issue2888.java
+++ b/checker/tests/nullness/Issue2888.java
@@ -1,0 +1,33 @@
+import com.sun.istack.internal.Nullable;
+
+class Issue2888 {
+    @Nullable Object[] noa;
+
+    void foo() {
+        noa = null;
+        // :: error: (accessing.nullable) :: error: (assignment.type.incompatible)
+        noa[0] = null;
+    }
+
+    @Nullable Object[] foo2(@Nullable Object[] p) {
+        noa = p;
+        noa = foo2(noa);
+        noa = foo2(p);
+        return p;
+    }
+
+    // The below is copied from Issue 2923.
+    public void bar1(@Nullable String... args) {
+        bar2(args);
+    }
+
+    private void bar2(@Nullable String... args) {
+        if (args != null && args.length > 0) {
+            @Nullable final String arg0 = args[0];
+            // :: warning: (known.nonnull)
+            if (arg0 != null) {
+                System.out.println("arg0: " + arg0);
+            }
+        }
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -13,6 +13,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -30,11 +31,24 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         AnnotatedTypeMirror result = TypeFromTree.fromTypeTree(f, node.getType());
 
         // Add primary annotations
-        List<? extends AnnotationTree> annos = node.getModifiers().getAnnotations();
-        if (annos != null && !annos.isEmpty()) {
-            List<AnnotationMirror> ams = TreeUtils.annotationsFromTypeAnnotationTrees(annos);
+        List<? extends AnnotationTree> annoTrees = node.getModifiers().getAnnotations();
+        if (annoTrees != null && !annoTrees.isEmpty()) {
+            List<AnnotationMirror> annos = TreeUtils.annotationsFromTypeAnnotationTrees(annoTrees);
             AnnotatedTypeMirror innerType = AnnotatedTypes.innerMostType(result);
-            innerType.addAnnotations(ams);
+            for (AnnotationMirror anno : annos) {
+                // The code here is similar to
+                // org.checkerframework.framework.util.element.ElementAnnotationUtil.addDeclarationAnnotationsFromElement.
+                if (AnnotationUtils.isDeclarationAnnotation(anno)
+                        // Always treat Checker Framework annotations as type annotations.
+                        && !AnnotationUtils.annotationName(anno)
+                                .startsWith("org.checkerframework")) {
+                    // Declaration annotations apply to the outer type.
+                    result.addAnnotation(anno);
+                } else {
+                    // Type annotations apply to the inner most type.
+                    innerType.addAnnotation(anno);
+                }
+            }
         }
 
         Element elt = TreeUtils.elementFromDeclaration(node);
@@ -58,7 +72,10 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
 
         // TODO: Needed to visit parameter types, etc.
         // It would be nicer if this didn't decode the information from the Element and
-        // instead also used the Tree.
+        // instead also used the Tree. If this is implemented, then care needs to be taken to put
+        // any alias declaration annotations in the correct place for return types that are arrays.
+        // This would be similar to
+        // org.checkerframework.framework.util.element.ElementAnnotationUtil.addDeclarationAnnotationsFromElement.
         ElementAnnotationApplier.apply(result, elt, f);
         return result;
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1004,31 +1004,11 @@ public class AnnotatedTypes {
      * @return true iff the give array contains {@link ElementType#TYPE_USE}
      * @throws RuntimeException if the array contains both {@link ElementType#TYPE_USE} and
      *     something besides {@link ElementType#TYPE_PARAMETER}
-     * @deprecated Use {@link AnnotationUtils#hasTypeQualifierElementTypes(ElementType[], Class)}.
+     * @deprecated use {@link AnnotationUtils#hasTypeQualifierElementTypes(ElementType[], Class)}.
      */
     @Deprecated
     public static boolean hasTypeQualifierElementTypes(ElementType[] elements, Class<?> cls) {
-        // True if the array contains TYPE_USE
-        boolean hasTypeUse = false;
-        // Non-null if the array contains an element other than TYPE_USE or TYPE_PARAMETER
-        ElementType otherElementType = null;
-
-        for (ElementType element : elements) {
-            if (element == ElementType.TYPE_USE) {
-                hasTypeUse = true;
-            } else if (element != ElementType.TYPE_PARAMETER) {
-                otherElementType = element;
-            }
-            if (hasTypeUse && otherElementType != null) {
-                throw new BugInCF(
-                        "@Target meta-annotation should not contain both TYPE_USE and "
-                                + otherElementType
-                                + ", for annotation "
-                                + cls.getName());
-            }
-        }
-
-        return hasTypeUse;
+        return AnnotationUtils.hasTypeQualifierElementTypes(elements, cls);
     }
 
     private static String annotationClassName =

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -86,6 +86,8 @@ public class ElementAnnotationUtil {
      */
     static void addDeclarationAnnotationsFromElement(
             final AnnotatedTypeMirror type, final List<? extends AnnotationMirror> annotations) {
+        // The code here should be similar to
+        // org.checkerframework.framework.type.TypeFromMemberVisitor.visitVariable
         AnnotatedTypeMirror innerType = AnnotatedTypes.innerMostType(type);
         if (innerType != type) {
             for (AnnotationMirror annotation : annotations) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -810,6 +810,28 @@ public class AnnotationUtils {
     }
 
     /**
+     * Returns true if anno is a declaration annotation. In other words, returns true if anno cannot
+     * be written on uses of types.
+     *
+     * @param anno the AnnotationMirror
+     * @return true if anno is a declaration annotation.
+     */
+    public static boolean isDeclarationAnnotation(AnnotationMirror anno) {
+        TypeElement elem = (TypeElement) anno.getAnnotationType().asElement();
+        Target t = elem.getAnnotation(Target.class);
+        if (t == null) {
+            return true;
+        }
+
+        for (ElementType elementType : t.value()) {
+            if (elementType == ElementType.TYPE_USE) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Returns true if the given array contains {@link ElementType#TYPE_USE}, false otherwise.
      *
      * @param elements an array of {@link ElementType} values


### PR DESCRIPTION
…2888) (#2927)

This is already the case for elements, so this fix is for trees.

Fixes #2888.